### PR TITLE
chore: replace lodash with lodash-es in package.json and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-query-devtools": "^5.75.2",
         "axios": "^1.9.0",
         "clsx": "^2.1.1",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "qs": "^6.14.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -27,13 +27,13 @@
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
         "@eslint/js": "^9.26.0",
         "@tailwindcss/vite": "^4.1.5",
-        "@types/lodash": "^4.17.16",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^22.15.3",
         "@types/qs": "^6.9.18",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@vitejs/plugin-react-swc": "^3.9.0",
-        "@vitest/coverage-v8": "^3.1.2",
+        "@vitest/coverage-v8": "^3.1.3",
         "@vitest/eslint-plugin": "^1.1.44",
         "autocorrect-node": "^2.14.0",
         "commitizen": "^4.3.1",
@@ -73,7 +73,7 @@
         "vite-plugin-checker": "^0.9.2",
         "vite-plugin-svgr": "^4.3.0",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.1.2"
+        "vitest": "^3.1.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3939,6 +3939,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -4458,9 +4468,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.2.tgz",
-      "integrity": "sha512-XDdaDOeaTMAMYW7N63AqoK32sYUWbXnTkC6tEbVcu3RlU1bB9of32T+PGf8KZvxqLNqeXhafDFqCkwpf2+dyaQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.3.tgz",
+      "integrity": "sha512-cj76U5gXCl3g88KSnf80kof6+6w+K4BjOflCl7t6yRJPDuCrHtVu0SgNYOUARJOL5TI8RScDbm5x4s1/P9bvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4481,8 +4491,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.1.2",
-        "vitest": "3.1.2"
+        "@vitest/browser": "3.1.3",
+        "vitest": "3.1.3"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4512,14 +4522,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.3.tgz",
+      "integrity": "sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/spy": "3.1.3",
+        "@vitest/utils": "3.1.3",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -4528,13 +4538,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.3.tgz",
+      "integrity": "sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.2",
+        "@vitest/spy": "3.1.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4565,9 +4575,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.3.tgz",
+      "integrity": "sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4578,13 +4588,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.3.tgz",
+      "integrity": "sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.2",
+        "@vitest/utils": "3.1.3",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4592,13 +4602,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.3.tgz",
+      "integrity": "sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.3",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -4607,9 +4617,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.3.tgz",
+      "integrity": "sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4620,13 +4630,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.1.3",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -11278,13 +11288,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -16390,15 +16400,15 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.3.tgz",
+      "integrity": "sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
         "vite": "^5.0.0 || ^6.0.0"
       },
@@ -16582,19 +16592,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.3.tgz",
+      "integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/expect": "3.1.3",
+        "@vitest/mocker": "3.1.3",
+        "@vitest/pretty-format": "^3.1.3",
+        "@vitest/runner": "3.1.3",
+        "@vitest/snapshot": "3.1.3",
+        "@vitest/spy": "3.1.3",
+        "@vitest/utils": "3.1.3",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.2.1",
@@ -16607,7 +16617,7 @@
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
+        "vite-node": "3.1.3",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -16623,8 +16633,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
+        "@vitest/browser": "3.1.3",
+        "@vitest/ui": "3.1.3",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@tanstack/react-query-devtools": "^5.75.2",
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "qs": "^6.14.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -64,13 +64,13 @@
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
     "@eslint/js": "^9.26.0",
     "@tailwindcss/vite": "^4.1.5",
-    "@types/lodash": "^4.17.16",
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.15.3",
     "@types/qs": "^6.9.18",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react-swc": "^3.9.0",
-    "@vitest/coverage-v8": "^3.1.2",
+    "@vitest/coverage-v8": "^3.1.3",
     "@vitest/eslint-plugin": "^1.1.44",
     "autocorrect-node": "^2.14.0",
     "commitizen": "^4.3.1",
@@ -110,6 +110,6 @@
     "vite-plugin-checker": "^0.9.2",
     "vite-plugin-svgr": "^4.3.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.1.2"
+    "vitest": "^3.1.3"
   }
 }

--- a/src/utils/url/index.ts
+++ b/src/utils/url/index.ts
@@ -1,4 +1,4 @@
-import { includes, merge, omitBy } from 'lodash';
+import { includes, merge, omitBy } from 'lodash-es';
 import * as qs from 'qs';
 
 const ignoreQueryPrefix = true;


### PR DESCRIPTION
Switch from lodash to lodash-es for better tree-shaking and update various dependencies to their latest versions.