### PR TITLE
ci: update Docker workflow branch triggers

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - main
+      - '**'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - '**'
+      - '*'
     tags:
       - '*'
   workflow_dispatch:


### PR DESCRIPTION
Modify the Docker workflow to trigger on all branches instead of just the main branch, allowing for more flexibility in CI processes.