### PR TITLE
chore(prettier): update prettier config type annotation

### DIFF
--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,4 +1,4 @@
-/** @type {import('prettier').Config} */
+/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
 export default {
   singleQuote: true,
   plugins: ['prettier-plugin-tailwindcss'],


### PR DESCRIPTION
- extend jsdoc type to include prettier-plugin-tailwindcss options
- helps editors pick up plugin options for safer config

Signed-off-by: donniean <donniean1@gmail.com>