### PR TITLE
ci(github): enable test execution in CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      # - name: Test
-      #   run: pnpm run test
+      - name: Test
+        run: pnpm run test
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Re-enable the `Test` step in `.github/workflows/ci.yaml` so PR CI runs `pnpm run test` again.
- Restore test coverage enforcement now that the ESLint v10 `FlatESLint is not a constructor` blocker described in #2098 is no longer reproduced with the current dependency set.

## Validation

- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`

Fixes #2098