### PR TITLE
fix(eslint): restore i18next flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { fixupPluginRules, includeIgnoreFile } from '@eslint/compat';
+import { includeIgnoreFile } from '@eslint/compat';
 import eslint from '@eslint/js';
 import eslintPluginEslintCommentsConfigs from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import eslintPluginQuery from '@tanstack/eslint-plugin-query';
@@ -295,14 +295,7 @@ export default defineConfig([
     name: 'i18next/recommended',
     files: ['src/**'],
     ignores: ['**/tests/**', '**/*.test.*', '**/mocks/**', '**/*.mock.*'],
-    // extends: [eslintPluginI18next.configs['flat/recommended']],
-    // https://github.com/edvardchen/eslint-plugin-i18next/issues/151#issuecomment-3942781201
-    plugins: {
-      i18next: fixupPluginRules(eslintPluginI18next),
-    },
-    rules: {
-      'i18next/no-literal-string': 'error',
-    },
+    extends: [eslintPluginI18next.configs['flat/recommended']],
   },
   {
     name: 'custom/node',


### PR DESCRIPTION
## Summary

- Restore `eslint-plugin-i18next` to use its native `flat/recommended` config under ESLint v10.
- Remove the temporary `fixupPluginRules` workaround that manually re-declared `i18next/no-literal-string`.

## Root Cause

Issue #2099 tracked recovering the plugin configuration after ESLint v10 compatibility work. The current `eslint-plugin-i18next@6.1.4` flat config now works with `eslint@10.4.1`, so the local workaround is no longer needed.

## Validation

- `pnpm run lint:js`
- `pnpm run test`
- `pnpm run build`
- `pnpm run lint`

Closes #2099