### PR TITLE
fix(build): recover eslint checker

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,11 +52,10 @@ export default defineConfig(({ mode }) => {
       checker({
         overlay: { initialIsOpen: 'error' },
         typescript: true,
-        // https://github.com/fi3ework/vite-plugin-checker/issues/647
-        // eslint: {
-        //   lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
-        //   useFlatConfig: true,
-        // },
+        eslint: {
+          lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
+          useFlatConfig: true,
+        },
         stylelint: {
           lintCommand: 'stylelint ./src/**/*.css',
         },


### PR DESCRIPTION
## Summary

- Restore the `vite-plugin-checker` ESLint checker in `vite.config.ts`.
- Keep the checker on flat config mode for the current ESLint v10 toolchain.

## Root Cause

PR #2138 disabled the checker ESLint integration while `vite-plugin-checker` lacked ESLint v10 compatibility. The project now uses `vite-plugin-checker@0.14.1`, whose ESLint peer range and runtime handling support ESLint v10 flat config mode, so the previous workaround can be removed.

## Validation

- `pnpm exec vite --host 127.0.0.1 --port 4173` showed `[ESLint] Found 0 error and 0 warning`
- `pnpm run lint`
- `pnpm run lint:js`
- `pnpm run test`
- `pnpm run build`
- `npx react-doctor@latest --verbose --diff`

Closes #2139