### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/actions/sanitize-ref-name/action.yaml
+++ b/.github/actions/sanitize-ref-name/action.yaml
@@ -90,27 +90,37 @@ runs:
   steps:
     - id: sanitize
       shell: bash
+      env:
+        INPUT_ALLOWED_CHARS: ${{ inputs.allowed-chars }}
+        INPUT_CASE: ${{ inputs.case }}
+        INPUT_FALLBACK: ${{ inputs.fallback }}
+        INPUT_MAX_LENGTH: ${{ inputs.max-length }}
+        INPUT_PREFIX: ${{ inputs.prefix }}
+        INPUT_REF_NAME: ${{ inputs.ref-name }}
+        INPUT_REPLACEMENT: ${{ inputs.replacement }}
+        INPUT_START_CHARS: ${{ inputs.start-chars }}
+        INPUT_TARGET: ${{ inputs.target }}
       run: |
         # cSpell: ignore pipefail
         set -euo pipefail
 
         # 1) read inputs and basic defaults
-        ref_input="${{ inputs.ref-name }}"
+        ref_input="$INPUT_REF_NAME"
         if [ -z "$ref_input" ]; then
           # use parameter expansion to avoid unset error under set -u
           ref_input="${GITHUB_REF_NAME-}"
         fi
 
-        target="${{ inputs.target }}"
+        target="$INPUT_TARGET"
         target="$(printf '%s' "${target:-docker-tag}" | tr '[:upper:]' '[:lower:]')"
 
-        allowed_extra="${{ inputs.allowed-chars }}"
-        replacement="${{ inputs.replacement }}"
-        case_opt="${{ inputs.case }}"
-        start_override="${{ inputs.start-chars }}"
-        prefix="${{ inputs.prefix }}"
-        fallback="${{ inputs.fallback }}"
-        max_length_input="${{ inputs.max-length }}"
+        allowed_extra="$INPUT_ALLOWED_CHARS"
+        replacement="$INPUT_REPLACEMENT"
+        case_opt="$INPUT_CASE"
+        start_override="$INPUT_START_CHARS"
+        prefix="$INPUT_PREFIX"
+        fallback="$INPUT_FALLBACK"
+        max_length_input="$INPUT_MAX_LENGTH"
 
         replacement="${replacement:--}"
         case_opt="$(printf '%s' "${case_opt:-lower}" | tr '[:upper:]' '[:lower:]')"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,13 @@
 name: CI
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   bump:
+    permissions:
+      contents: read
     uses: donniean/hub/.github/workflows/dependencies.bump.yaml@main
     with:
       app-client-id: ${{ vars.APP_CLIENT_ID }}

--- a/.github/workflows/dependencies.bump.yaml
+++ b/.github/workflows/dependencies.bump.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   bump:
     uses: donniean/hub/.github/workflows/dependencies.bump.yaml@main
+    with:
+      app-client-id: ${{ vars.APP_CLIENT_ID }}
     secrets:
-      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -47,18 +47,18 @@ jobs:
           TAG="latest"
 
           if [[ "$REF" == refs/tags/* ]]; then
-            TAG="$REF_NAME"
+            TAG="$SANITIZED_REF_NAME"
           elif [[ "$REF" == "refs/heads/main" ]]; then
             TAG="latest"
           elif [[ "$REF" == refs/heads/* ]]; then
             TAG="$SANITIZED_REF_NAME"
           fi
 
-          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Build and Push
         uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
-          tags: donniean/react-app:${{ env.TAG }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ env.TAG }}
           push: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,8 +1,5 @@
 name: Build and Push Docker Image
 
-permissions:
-  contents: read
-
 on:
   push:
     branches:
@@ -10,6 +7,9 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set Docker Image Tag
         env:

--- a/.github/workflows/pull-requests.auto-merge.yaml
+++ b/.github/workflows/pull-requests.auto-merge.yaml
@@ -4,4 +4,7 @@ on:
 
 jobs:
   auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: donniean/hub/.github/workflows/pull-requests.auto-merge.yaml@main

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -5,5 +5,7 @@ on:
 jobs:
   auto-update:
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
+    with:
+      app-client-id: ${{ vars.APP_CLIENT_ID }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   auto-update:
+    permissions: {}
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
     with:
       app-client-id: ${{ vars.APP_CLIENT_ID }}

--- a/.github/workflows/pull-requests.auto-update.yaml
+++ b/.github/workflows/pull-requests.auto-update.yaml
@@ -6,5 +6,4 @@ jobs:
   auto-update:
     uses: donniean/hub/.github/workflows/pull-requests.auto-update.yaml@main
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
     'Vercel',
     // Docker
     'Buildx',
+    'DOCKERHUB',
     // files
     '.autocorrectignore',
     '.autocorrectrc',


### PR DESCRIPTION
## Summary

- Configure explicit least-privilege GitHub Actions permissions for local and reusable workflows.
- Move reusable workflow caller permissions to the calling jobs so token access is scoped to each invocation.
- Improve CI workflow reliability around dependency installation, Docker tagging, credential usage, and local composite action inputs.

## Validation

- `yq eval '.' .github/workflows/*.yaml .github/actions/*/action.yaml > /dev/null`
- `pnpm run lint:format`

## Notes

- `actionlint` was not available in the local environment during this PR creation step.