### PR TITLE
fix(docker): enable pnpm in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:lts-slim AS builder
 
 WORKDIR /app
 
+RUN corepack enable
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN pnpm install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-ENV NODE_ENV=production
 RUN pnpm run build
 
 FROM nginx:stable-alpine AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:lts-slim AS builder
+FROM node:lts-slim AS build
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME/bin:$PATH"
+RUN corepack enable
 
 WORKDIR /app
-
-RUN corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
@@ -13,13 +15,10 @@ COPY . .
 ENV NODE_ENV=production
 RUN pnpm run build
 
-
-FROM nginx:stable-alpine
+FROM nginx:stable-alpine AS runtime
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-
-COPY --from=builder /app/dist/ /usr/share/nginx/html/
-
+COPY --from=build /app/dist/ /usr/share/nginx/html/
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary

- Enable Corepack in the Docker build stage before invoking pnpm.
- Keep the build and runtime stages named explicitly.
- Remove the redundant `NODE_ENV=production` build-stage environment variable.

## Why

The Docker publishing workflow failed after PR #2377 because the `node:lts-slim` builder image includes Corepack but does not expose a `pnpm` command until Corepack shims are enabled. The build stopped at `RUN pnpm install --frozen-lockfile` with `/bin/sh: 1: pnpm: not found`.

This change restores the pnpm shim setup while keeping the final runtime image limited to nginx and the built static assets.

## Validation

- `git diff --check`
- `docker buildx build --platform linux/amd64 --progress=plain --tag react-app:current-dockerfile-amd64 --load .`
- `docker buildx build --platform linux/arm64 --progress=plain --tag react-app:current-dockerfile-arm64 --load .`
- Container smoke test against the amd64 image:
  - `/` returned `200 text/html`
  - `/non-existent-route` returned `200 text/html`
  - referenced JS and CSS assets returned `200`