### PR TITLE
chore(deps): add oxfmt and oxlint to cspell ignore list

### DIFF
--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -45,6 +45,8 @@ export default defineConfig({
     'markdownlint',
     'npmjs',
     'numbro',
+    'oxfmt',
+    'oxlint',
     'rimraf',
     'sonarjs',
     'stylelint',


### PR DESCRIPTION
- include oxfmt and oxlint in the dictionary configuration to prevent spelling errors during linting

Signed-off-by: donniean <donniean1@gmail.com>