### PR TITLE
docs(conventions): remove redundant introduction text

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,7 +1,5 @@
 # Conventions
 
-This file is the authoritative source for `react-app` project structure and implementation conventions. [README.md](../README.md) keeps only the repository purpose, common commands, and high-level entry points.
-
 ## Routing
 
 - Route definitions are in [`src/app/routes.tsx`](../src/app/routes.tsx).


### PR DESCRIPTION
- delete outdated introductory sentence regarding project structure
- simplify documentation header for better readability

Signed-off-by: donniean <donniean1@gmail.com>