### PR TITLE
chore(imports): enforce type import style

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -18,6 +18,15 @@
 
 - React component directory names and file names use `kebab-case`, not `PascalCase`.
 
+## Imports
+
+- Use `./` for imports from the same directory.
+- Use one-level `../` imports for nearby files within the same feature, module, or local folder group.
+- Use the configured `@/` alias for cross-boundary imports from `src/`, including imports across features, routes, app composition, shared components, config, utilities, assets, and styles.
+- Avoid deep parent traversal such as `../../...` or deeper. ESLint restricts this with `no-restricted-imports`.
+- Use top-level `import type` and `export type` for pure type-only imports and exports.
+- Use inline `type` specifiers only when the same import or export statement mixes runtime values and types.
+
 ## i18n
 
 - User-facing text should use i18n resources; do not write literal strings directly. ESLint enables `i18next/no-literal-string`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -115,6 +115,12 @@ export default defineConfig([
           patterns: ['../..'],
         },
       ],
+      'no-duplicate-imports': [
+        'error',
+        {
+          allowSeparateTypeImports: false,
+        },
+      ],
       'no-useless-call': 'error',
     },
   },
@@ -124,12 +130,9 @@ export default defineConfig([
       'import-x/first': 'error',
       'import-x/newline-after-import': 'error',
       'import-x/no-cycle': 'error',
-      'import-x/no-duplicates': [
-        'error',
-        {
-          considerQueryString: true,
-        },
-      ],
+      // Use the core rule because import-x's inline type fixer can emit invalid
+      // syntax for default imports combined with named type imports.
+      'import-x/no-duplicates': 'off',
       'import-x/no-extraneous-dependencies': [
         'error',
         {
@@ -217,9 +220,21 @@ export default defineConfig([
       ],
     },
     rules: {
-      '@typescript-eslint/consistent-type-exports': 'error',
-      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/consistent-type-exports': [
+        'error',
+        {
+          fixMixedExportsWithInlineTypeSpecifier: true,
+        },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+          fixStyle: 'inline-type-imports',
+        },
+      ],
       '@typescript-eslint/member-ordering': 'error',
+      '@typescript-eslint/no-import-type-side-effects': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,164 @@ const storyGlobs = [
 ];
 const devDependencyGlobs = [...nodeGlobs, ...testGlobs, ...storyGlobs];
 
+function getImportSource(node) {
+  return typeof node.source.value === 'string' ? node.source.value : undefined;
+}
+
+function isNamedTypeImport(node) {
+  return (
+    node.importKind === 'type' &&
+    node.specifiers.length > 0 &&
+    node.specifiers.every((specifier) => specifier.type === 'ImportSpecifier')
+  );
+}
+
+function isMergeableValueImport(node) {
+  return (
+    node.importKind !== 'type' &&
+    node.specifiers.length > 0 &&
+    !node.specifiers.some(
+      (specifier) => specifier.type === 'ImportNamespaceSpecifier',
+    )
+  );
+}
+
+function collectImportDeclarationsBySource(node) {
+  const importsBySource = new Map();
+
+  for (const statement of node.body) {
+    if (statement.type !== 'ImportDeclaration') {
+      continue;
+    }
+
+    const source = getImportSource(statement);
+
+    if (!source) {
+      continue;
+    }
+
+    const imports = importsBySource.get(source) ?? [];
+    imports.push(statement);
+    importsBySource.set(source, imports);
+  }
+
+  return importsBySource;
+}
+
+function getMergeableValueImport(imports) {
+  for (const importDeclaration of imports) {
+    if (isMergeableValueImport(importDeclaration)) {
+      return importDeclaration;
+    }
+  }
+}
+
+const mergeTypeImportsRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Merge named type imports into existing value imports from the same source.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      mergeTypeImport:
+        "Merge this type import from '{{source}}' into the existing value import.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    function removeImportDeclaration(fixer, node) {
+      let end = node.range[1];
+
+      if (sourceCode.text.slice(end, end + 2) === '\r\n') {
+        end += 2;
+      } else if (sourceCode.text[end] === '\n') {
+        end += 1;
+      }
+
+      return fixer.removeRange([node.range[0], end]);
+    }
+
+    function insertIntoValueImport(fixer, node, typeSpecifiers) {
+      let namedSpecifier;
+
+      for (const specifier of node.specifiers) {
+        if (specifier.type === 'ImportSpecifier') {
+          namedSpecifier = specifier;
+          break;
+        }
+      }
+
+      if (namedSpecifier) {
+        let openingBrace;
+
+        for (const token of sourceCode.getTokens(node)) {
+          if (token.value === '{') {
+            openingBrace = token;
+            break;
+          }
+        }
+
+        return fixer.insertTextAfter(
+          openingBrace,
+          ` ${typeSpecifiers.join(', ')},`,
+        );
+      }
+
+      return fixer.insertTextAfter(
+        node.specifiers.at(-1),
+        `, { ${typeSpecifiers.join(', ')} }`,
+      );
+    }
+
+    return {
+      Program(node) {
+        const importsBySource = collectImportDeclarationsBySource(node);
+
+        for (const [source, imports] of importsBySource) {
+          const valueImport = getMergeableValueImport(imports);
+
+          if (!valueImport) {
+            continue;
+          }
+
+          for (const typeImport of imports) {
+            if (!isNamedTypeImport(typeImport)) {
+              continue;
+            }
+
+            context.report({
+              node: typeImport,
+              messageId: 'mergeTypeImport',
+              data: {
+                source,
+              },
+              fix(fixer) {
+                const typeSpecifiers = typeImport.specifiers.map(
+                  (specifier) => `type ${sourceCode.getText(specifier)}`,
+                );
+
+                return [
+                  insertIntoValueImport(fixer, valueImport, typeSpecifiers),
+                  removeImportDeclaration(fixer, typeImport),
+                ];
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+const eslintPluginLocal = {
+  rules: {
+    'merge-type-imports': mergeTypeImportsRule,
+  },
+};
+
 export default defineConfig([
   includeIgnoreFile(gitignorePath, 'custom/gitignore'),
   globalIgnores(['**/*.min.*'], 'custom/ignore'),
@@ -115,12 +273,6 @@ export default defineConfig([
           patterns: ['../..'],
         },
       ],
-      'no-duplicate-imports': [
-        'error',
-        {
-          allowSeparateTypeImports: false,
-        },
-      ],
       'no-useless-call': 'error',
     },
   },
@@ -130,9 +282,12 @@ export default defineConfig([
       'import-x/first': 'error',
       'import-x/newline-after-import': 'error',
       'import-x/no-cycle': 'error',
-      // Use the core rule because import-x's inline type fixer can emit invalid
-      // syntax for default imports combined with named type imports.
-      'import-x/no-duplicates': 'off',
+      'import-x/no-duplicates': [
+        'error',
+        {
+          considerQueryString: true,
+        },
+      ],
       'import-x/no-extraneous-dependencies': [
         'error',
         {
@@ -214,6 +369,9 @@ export default defineConfig([
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    plugins: {
+      local: eslintPluginLocal,
+    },
     settings: {
       'import-x/resolver-next': [
         createTypeScriptImportResolver({ alwaysTryTypes: true }),
@@ -235,6 +393,7 @@ export default defineConfig([
       ],
       '@typescript-eslint/member-ordering': 'error',
       '@typescript-eslint/no-import-type-side-effects': 'error',
+      'local/merge-type-imports': 'error',
     },
   },
   {

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,5 +1,4 @@
-import type { ClassValue } from 'clsx';
-import { clsx } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {


### PR DESCRIPTION
## Summary

- Document import path conventions for local, parent, and `@/` alias imports.
- Configure TypeScript ESLint rules to prefer inline `type` specifiers for mixed value/type imports and exports.
- Add `no-duplicate-imports` with `allowSeparateTypeImports: false` so separate value/type imports from the same module are reported.
- Add a guardrail against pure inline type imports that would leave side-effect imports behind.
- Update the existing `clsx` import in `src/utils/cn.ts` to match the convention.
- Disable `import-x/no-duplicates`; its inline type fixer can produce invalid syntax for default imports combined with named type imports.

## Impact

This enforces the intended import style without relying on the unsafe `import-x/no-duplicates` inline fixer. Separate value/type imports now fail lint and should be written as valid inline forms, such as `import json2md, { type DataObject } from 'json2md'` or `import { value, type Type } from 'module'`.

## Validation

- `pnpm run lint:js`
- `pnpm run lint:md`
- `pnpm run lint:format`
- `pnpm run lint:types`
- Reproduced the `import-x/no-duplicates` `prefer-inline` issue in `~/repos/node-app`; verified `pnpm run lint:js:fix` passes with the safer core-rule strategy and a valid inline default-plus-type import.