### PR TITLE
chore(tooling): remove pnpm install guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "i18n:status": "i18next-cli status",
     "i18n:sync": "i18next-cli sync",
     "i18n:types": "i18next-cli types && prettier --write src/@types/i18next-resources.d.ts",
-    "preinstall": "npx only-allow@latest pnpm",
     "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix|^lint:knip$)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",


### PR DESCRIPTION
## Summary

- Remove the deprecated `only-allow` preinstall guard.
- Keep `packageManager` as the pnpm version source of truth.
- Rely on the pnpm lockfile and CI pnpm setup for package-manager consistency.

## Validation

- `pnpm run format:package-json:check`
