### PR TITLE
chore(cspell): add oxlint-tsgolint to dictionary

### DIFF
--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig({
     'numbro',
     'oxfmt',
     'oxlint',
+    'oxlint-tsgolint',
     'rimraf',
     'sonarjs',
     'stylelint',


### PR DESCRIPTION
- include oxlint-tsgolint in the ignore/words list to avoid spelling errors

Signed-off-by: donniean <donniean1@gmail.com>