### PR TITLE
chore(cspell): update dictionary configuration

### DIFF
--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -47,7 +47,6 @@ export default defineConfig({
     'numbro',
     'oxfmt',
     'oxlint',
-    'oxlint-tsgolint',
     'rimraf',
     'sonarjs',
     'stylelint',
@@ -61,7 +60,7 @@ export default defineConfig({
     'nodenext',
     'classname',
     // Vite
-    'VITE',
+    'vite',
     // custom
     'donniean',
   ],

--- a/cspell.config.mjs
+++ b/cspell.config.mjs
@@ -9,10 +9,10 @@ export default defineConfig({
     'webstorm',
     'wechat',
     // brands
-    'Vercel',
+    'vercel',
     // Docker
-    'Buildx',
-    'DOCKERHUB',
+    'buildx',
+    'dockerhub',
     // files
     '.autocorrectignore',
     '.autocorrectrc',

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,5 +1,5 @@
 import i18n from 'i18next';
-// cspell: ignore languagedetector
+// cSpell: ignore languagedetector
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
@@ -21,7 +21,7 @@ export const i18nInit = defaultI18n
       'zh-CN': ['zh-Hans'],
       default: [__I18N_DEFAULT_LOCALE__],
     },
-    // cspell: ignore Lngs
+    // cSpell: ignore Lngs
     nonExplicitSupportedLngs: true,
     ns: namespaces,
     defaultNS: __I18N_DEFAULT_NAMESPACE__,


### PR DESCRIPTION
- remove obsolete 'oxlint-tsgolint' from word list
- normalize 'VITE' to lowercase 'vite' for consistent casing

Signed-off-by: donniean <donniean1@gmail.com>