### PR TITLE
fix(deps): skip broken vite-plugin-checker 0.14.3

### DIFF
--- a/.ncurc.mjs
+++ b/.ncurc.mjs
@@ -1,8 +1,16 @@
 import { defineConfig } from 'npm-check-updates';
 
 const majorLockedDependencies = new Set(['@types/node', 'typescript']);
+const blockedDependencyVersions = new Map([
+  // vite-plugin-checker@0.14.3 is missing required runtime files.
+  // https://github.com/fi3ework/vite-plugin-checker/issues/766
+  ['vite-plugin-checker', new Set(['0.14.3'])],
+]);
 
 export default defineConfig({
+  filterResults: (dependencyName, { upgradedVersion }) => {
+    return !blockedDependencyVersions.get(dependencyName)?.has(upgradedVersion);
+  },
   target: (dependencyName) => {
     if (majorLockedDependencies.has(dependencyName)) {
       return 'minor';


### PR DESCRIPTION
## Summary

- Add an `npm-check-updates` `filterResults` guard for `vite-plugin-checker@0.14.3`.
- Keep later versions, such as `0.14.4`, eligible for updates.
- Document the upstream issue in the config comment.

## Why

`vite-plugin-checker@0.14.3` was published without required runtime files and can break consumers during development. The guard blocks only that exact version so dependency updates can resume once a fixed release is available.

Refs: https://github.com/fi3ework/vite-plugin-checker/issues/766

## Validation

- `pnpm run format:prettier:check`
- `pnpm run lint:oxlint`
- `pnpm run lint:spellcheck`
- Controlled `npm-check-updates` registry check: `0.14.3` is filtered out.
- Controlled `npm-check-updates` registry check: `0.14.4` remains eligible.
- Real registry check with `--cooldown 0`: `0.14.4` remains eligible.