### PR TITLE
style(lint): update import and export lint conventions

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -287,3 +287,10 @@ URL search-related names keep these meanings:
 - Feature-level `index.ts` public APIs and global barrel files SHOULD NOT be the baseline.
 - Small module entries MAY be used, but they must represent real module boundaries.
 - Imports MUST follow the dependency direction defined by this document.
+- Type-only imports MUST use top-level `import type` when the imported module provides only types to the current file.
+- Mixed value/type imports from the same module SHOULD use inline `type` specifiers, for example `import { type Value, value } from './value';`.
+- Type-only exports and re-exports MUST use top-level `export type`.
+- Mixed value/type exports and re-exports SHOULD use inline `type` specifiers, for example `export { type Value, value } from './value';`.
+- Named import specifiers SHOULD be sorted automatically by Oxlint; import declaration ordering is handled by Oxfmt.
+- Application source SHOULD use named exports. Default exports are allowed for tooling configuration, generated files, and external framework or library conventions.
+- Implementation modules SHOULD export at declaration sites. Explicit export lists SHOULD be reserved for module entry points or intentional public API selection.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -128,13 +128,6 @@ export default defineConfig<OxlintConfig>({
   overrides: [
     {
       files: ['**'],
-      excludeFiles: ['*.config.*', 'src/@types/**'],
-      rules: {
-        'import/no-default-export': 'error',
-      },
-    },
-    {
-      files: ['**'],
       excludeFiles: ['src/**'],
       env: {
         node: true,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,7 +1,7 @@
 import pluginQuery from '@tanstack/eslint-plugin-query';
 import pluginRouter from '@tanstack/eslint-plugin-router';
 import pluginI18next from 'eslint-plugin-i18next';
-import { defineConfig, type OxlintConfig } from 'oxlint';
+import { type OxlintConfig, defineConfig } from 'oxlint';
 
 export default defineConfig<OxlintConfig>({
   // https://oxc.rs/docs/guide/usage/linter/config-file-reference.html#options
@@ -75,7 +75,6 @@ export default defineConfig<OxlintConfig>({
       'error',
       {
         ignoreDeclarationSort: true,
-        ignoreCase: true,
       },
     ],
     'import/first': 'error',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,8 +1,7 @@
 import pluginQuery from '@tanstack/eslint-plugin-query';
 import pluginRouter from '@tanstack/eslint-plugin-router';
 import pluginI18next from 'eslint-plugin-i18next';
-import type { OxlintConfig } from 'oxlint';
-import { defineConfig } from 'oxlint';
+import { defineConfig, type OxlintConfig } from 'oxlint';
 
 export default defineConfig<OxlintConfig>({
   // https://oxc.rs/docs/guide/usage/linter/config-file-reference.html#options
@@ -72,6 +71,13 @@ export default defineConfig<OxlintConfig>({
     'eslint/no-var': 'error',
     'eslint/prefer-const': 'error',
     'eslint/prefer-template': 'error',
+    'eslint/sort-imports': [
+      'error',
+      {
+        ignoreDeclarationSort: true,
+        ignoreCase: true,
+      },
+    ],
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-cycle': 'error',
@@ -79,10 +85,23 @@ export default defineConfig<OxlintConfig>({
       'error',
       {
         considerQueryString: true,
+        preferInline: true,
       },
     ],
-    'typescript/consistent-type-exports': 'error',
-    'typescript/consistent-type-imports': 'error',
+    'typescript/consistent-type-exports': [
+      'error',
+      {
+        fixMixedExportsWithInlineTypeSpecifier: true,
+      },
+    ],
+    'typescript/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+        fixStyle: 'inline-type-imports',
+        disallowTypeAnnotations: true,
+      },
+    ],
     'typescript/no-empty-object-type': 'error',
     'typescript/no-explicit-any': 'error',
     'typescript/no-import-type-side-effects': 'error',
@@ -107,6 +126,13 @@ export default defineConfig<OxlintConfig>({
     'vitest/prefer-importing-vitest-globals': 'error',
   },
   overrides: [
+    {
+      files: ['**'],
+      excludeFiles: ['*.config.*', 'src/@types/**'],
+      rules: {
+        'import/no-default-export': 'error',
+      },
+    },
     {
       files: ['**'],
       excludeFiles: ['src/**'],

--- a/src/app/providers/router.tsx
+++ b/src/app/providers/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router';
+import { RouterProvider, createBrowserRouter } from 'react-router';
 
 import { routes } from '../routes';
 

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,5 +1,4 @@
-import type { ClassValue } from 'clsx';
-import { clsx } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {


### PR DESCRIPTION
## Summary

- Add explicit TypeScript import/export conventions for type-only and mixed value/type exports.
- Configure Oxlint to prefer inline type specifiers for mixed imports and exports.
- Enable import member sorting while leaving import declaration ordering to Oxfmt.
- Update affected imports in source files to match the new rules.

## Requirement Fit

The current changes match the agreed direction for type-only imports/exports, mixed value/type import/export syntax, and import member sorting. `export *` remains allowed, matching the later decision not to enable `oxc/no-barrel-file`.

One intentional boundary remains: application source named exports are documented as a `SHOULD` convention, but `import/no-default-export` is not enforced by Oxlint in this branch. If that should be a hard rule, this PR needs an additional `src/**/*.ts(x)` override before merge.

## Validation

- `pnpm run lint`
- `pnpm run lint:oxlint`
- `pnpm run format:oxfmt:check`
- `pnpm run typecheck`
- `pnpm run lint:markdown`