### PR TITLE
chore: align repository configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,205 +13,205 @@
 ##   Handle line endings automatically for files detected as
 ##   text and leave all files detected as binary untouched.
 ##   This will handle all files NOT defined below.
-* text=lf
+*                 text=auto eol=lf
 
 # Source code
-*.bash text eol=lf
-*.bat text eol=crlf
-*.cmd text eol=crlf
-*.coffee text
-*.css text diff=css
-*.htm text diff=html
-*.html text diff=html
-*.inc text
-*.ini text
-*.js text
-*.mjs text
-*.cjs text
-*.json text
-*.jsx text
-*.less text
-*.ls text
-*.map text -diff
-*.od text
-*.onlydata text
-*.php text diff=php
-*.pl text
-*.ps1 text eol=crlf
-*.py text diff=python
-*.rb text diff=ruby
-*.sass text
-*.scm text
-*.scss text diff=css
-*.sh text eol=lf
-.husky/* text eol=lf
-*.sql text
-*.styl text
-*.tag text
-*.ts text
-*.tsx text
-*.xml text
-*.xhtml text diff=html
+*.bash            text eol=lf
+*.bat             text eol=crlf
+*.cmd             text eol=crlf
+*.coffee          text
+*.css             text diff=css
+*.htm             text diff=html
+*.html            text diff=html
+*.inc             text
+*.ini             text
+*.js              text
+*.mjs             text
+*.cjs             text
+*.json            text
+*.jsx             text
+*.less            text
+*.ls              text
+*.map             text -diff
+*.od              text
+*.onlydata        text
+*.php             text diff=php
+*.pl              text
+*.ps1             text eol=crlf
+*.py              text diff=python
+*.rb              text diff=ruby
+*.sass            text
+*.scm             text
+*.scss            text diff=css
+*.sh              text eol=lf
+.husky/*          text eol=lf
+*.sql             text
+*.styl            text
+*.tag             text
+*.ts              text
+*.tsx             text
+*.xml             text
+*.xhtml           text diff=html
 
 # Docker
-Dockerfile text
+Dockerfile        text
 
 # Documentation
-*.ipynb text eol=lf
-*.markdown text diff=markdown
-*.md text diff=markdown
-*.mdwn text diff=markdown
-*.mdown text diff=markdown
-*.mkd text diff=markdown
-*.mkdn text diff=markdown
-*.mdtxt text
-*.mdtext text
-*.txt text
-AUTHORS text
-CHANGELOG text
-CHANGES text
-CONTRIBUTING text
-COPYING text
-copyright text
-*COPYRIGHT* text
-INSTALL text
-license text
-LICENSE text
-NEWS text
-readme text
-*README* text
-TODO text
+*.ipynb           text eol=lf
+*.markdown        text diff=markdown
+*.md              text diff=markdown
+*.mdwn            text diff=markdown
+*.mdown           text diff=markdown
+*.mkd             text diff=markdown
+*.mkdn            text diff=markdown
+*.mdtxt           text
+*.mdtext          text
+*.txt             text
+AUTHORS           text
+CHANGELOG         text
+CHANGES           text
+CONTRIBUTING      text
+COPYING           text
+copyright         text
+*COPYRIGHT*       text
+INSTALL           text
+license           text
+LICENSE           text
+NEWS              text
+readme            text
+*README*          text
+TODO              text
 
 # Templates
-*.dot text
-*.ejs text
-*.erb text
-*.haml text
-*.handlebars text
-*.hbs text
-*.hbt text
-*.jade text
-*.latte text
-*.mustache text
-*.njk text
-*.phtml text
-*.svelte text
-*.tmpl text
-*.tpl text
-*.twig text
-*.vue text
+*.dot             text
+*.ejs             text
+*.erb             text
+*.haml            text
+*.handlebars      text
+*.hbs             text
+*.hbt             text
+*.jade            text
+*.latte           text
+*.mustache        text
+*.njk             text
+*.phtml           text
+*.svelte          text
+*.tmpl            text
+*.tpl             text
+*.twig            text
+*.vue             text
 
 # Configs
-*.cnf text
-*.conf text
-*.config text
-.editorconfig text
-.env text
-.gitattributes text
-.gitconfig text
-.htaccess text
-*.lock text -diff
-package.json text eol=lf
+*.cnf             text
+*.conf            text
+*.config          text
+.editorconfig     text
+*.env             text
+.gitattributes    text
+.gitconfig        text
+.htaccess         text
+*.lock            text -diff
+package.json      text eol=lf
 package-lock.json text eol=lf -diff
-pnpm-lock.yaml text eol=lf -diff
-.prettierrc text
-yarn.lock text -diff
-*.toml text
-*.yaml text
-*.yml text
-browserslist text
-Makefile text
-makefile text
+pnpm-lock.yaml    text eol=lf -diff
+.prettierrc       text
+yarn.lock         text -diff
+*.toml            text
+*.yaml            text
+*.yml             text
+browserslist      text
+Makefile          text
+makefile          text
 # Fixes syntax highlighting on GitHub to allow comments
-tsconfig.json linguist-language=JSON-with-Comments
+tsconfig.json     linguist-language=JSON-with-Comments
 
 # Heroku
-Procfile text
+Procfile          text
 
 # Graphics
-*.ai binary
-*.bmp binary
-*.eps binary
-*.gif binary
-*.gifv binary
-*.ico binary
-*.jng binary
-*.jp2 binary
-*.jpg binary
-*.jpeg binary
-*.jpx binary
-*.jxr binary
-*.pdf binary
-*.png binary
-*.psb binary
-*.psd binary
+*.ai              binary
+*.bmp             binary
+*.eps             binary
+*.gif             binary
+*.gifv            binary
+*.ico             binary
+*.jng             binary
+*.jp2             binary
+*.jpg             binary
+*.jpeg            binary
+*.jpx             binary
+*.jxr             binary
+*.pdf             binary
+*.png             binary
+*.psb             binary
+*.psd             binary
 # SVG treated as an asset (binary) by default.
-*.svg text
+*.svg             text
 # If you want to treat it as binary,
 # use the following line instead.
 # *.svg           binary
-*.svgz binary
-*.tif binary
-*.tiff binary
-*.wbmp binary
-*.webp binary
+*.svgz            binary
+*.tif             binary
+*.tiff            binary
+*.wbmp            binary
+*.webp            binary
 
 # Audio
-*.kar binary
-*.m4a binary
-*.mid binary
-*.midi binary
-*.mp3 binary
-*.ogg binary
-*.ra binary
+*.kar             binary
+*.m4a             binary
+*.mid             binary
+*.midi            binary
+*.mp3             binary
+*.ogg             binary
+*.ra              binary
 
 # Video
-*.3gpp binary
-*.3gp binary
-*.as binary
-*.asf binary
-*.asx binary
-*.avi binary
-*.fla binary
-*.flv binary
-*.m4v binary
-*.mng binary
-*.mov binary
-*.mp4 binary
-*.mpeg binary
-*.mpg binary
-*.ogv binary
-*.swc binary
-*.swf binary
-*.webm binary
+*.3gpp            binary
+*.3gp             binary
+*.as              binary
+*.asf             binary
+*.asx             binary
+*.avi             binary
+*.fla             binary
+*.flv             binary
+*.m4v             binary
+*.mng             binary
+*.mov             binary
+*.mp4             binary
+*.mpeg            binary
+*.mpg             binary
+*.ogv             binary
+*.swc             binary
+*.swf             binary
+*.webm            binary
 
 # Archives
-*.7z binary
-*.gz binary
-*.jar binary
-*.rar binary
-*.tar binary
-*.zip binary
+*.7z              binary
+*.gz              binary
+*.jar             binary
+*.rar             binary
+*.tar             binary
+*.zip             binary
 
 # Fonts
-*.ttf binary
-*.eot binary
-*.otf binary
-*.woff binary
-*.woff2 binary
+*.ttf             binary
+*.eot             binary
+*.otf             binary
+*.woff            binary
+*.woff2           binary
 
 # Executables
-*.exe binary
-*.pyc binary
+*.exe             binary
+*.pyc             binary
 # Prevents massive diffs caused by vendored, minified files
-**/.yarn/releases/** binary
-**/.yarn/plugins/** binary
+**/.yarn/releases/**   binary
+**/.yarn/plugins/**    binary
 
 # RC files (like .babelrc or .eslintrc)
-*.*rc text
+*.*rc             text
 
 # Ignore files (like .npmignore or .gitignore)
-*.*ignore text
+*.*ignore         text
 
 # Prevents massive diffs from built files
-dist/* binary
+dist/**           binary

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -3,15 +3,15 @@
  */
 export default {
   '*': [
-    'pnpm run format:oxfmt -- --no-error-on-unmatched-pattern',
-    'pnpm run lint:autocorrect:fix --',
-    () => 'pnpm run lint:spellcheck',
+    'oxfmt --no-error-on-unmatched-pattern',
+    'autocorrect --fix',
+    'cspell lint --no-progress --no-must-find-files --dot --gitignore',
     () => 'pnpm run i18n:types',
     () => 'pnpm run lint:i18n',
   ],
-  '*.{ts,tsx,mts,cts}': [() => 'pnpm run typecheck', 'vitest related --run'],
-  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'pnpm run lint:oxlint:fix --',
-  '*.css': () => 'pnpm run lint:styles:fix',
-  '*.html': () => 'pnpm run lint:html',
-  '*.md': () => 'pnpm run lint:markdown:fix',
+  '*.{ts,tsx,mts,cts}': [() => 'tsc --build', 'vitest related --run'],
+  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix',
+  '*.css': 'stylelint --fix',
+  '*.html': 'html-validate',
+  '*.md': 'markdownlint --dot --fix',
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -3,16 +3,15 @@
  */
 export default {
   '*': [
-    'oxfmt --no-error-on-unmatched-pattern',
-    'autocorrect --fix',
-    'cspell lint --no-progress --no-must-find-files --dot --gitignore',
+    'pnpm run format:oxfmt -- --no-error-on-unmatched-pattern',
+    'pnpm run lint:autocorrect:fix --',
+    () => 'pnpm run lint:spellcheck',
     () => 'pnpm run i18n:types',
     () => 'pnpm run lint:i18n',
   ],
-  '*.{ts,tsx}': () => 'tsc --build',
-  '*.{js,mjs,cjs,ts,tsx}': 'oxlint --fix',
-  '*.css': 'stylelint --fix',
-  '*.html': 'html-validate',
-  '*.md': 'markdownlint --dot --fix',
-  '*.ts': 'vitest related --run',
+  '*.{ts,tsx,mts,cts}': [() => 'pnpm run typecheck', 'vitest related --run'],
+  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'pnpm run lint:oxlint:fix --',
+  '*.css': () => 'pnpm run lint:styles:fix',
+  '*.html': () => 'pnpm run lint:html',
+  '*.md': () => 'pnpm run lint:markdown:fix',
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "i18n:status": "i18next-cli status",
     "i18n:sync": "i18next-cli sync",
     "i18n:types": "i18next-cli types && oxfmt src/@types/i18next-resources.d.ts",
-    "lint": "concurrently --group --timings \"pnpm:lint:*(!:fix)\" \"pnpm:format:*:check\" \"pnpm:typecheck\"",
+    "lint": "concurrently --group --timings \"pnpm:format:*:check\" \"pnpm:lint:*(!:fix)\" \"pnpm:typecheck\"",
     "lint:autocorrect": "autocorrect --lint",
     "lint:autocorrect:fix": "autocorrect --fix",
     "lint:fix": "concurrently --max-processes=1 --group --timings \"pnpm:lint:*:fix\" \"pnpm:format:*(!:check)\"",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -12,5 +12,5 @@
     "moduleResolution": "bundler",
     "types": ["node"]
   },
-  "include": ["config/**/*", "*.ts"]
+  "include": ["config/**/*", "*.ts", "*.mts", "*.cts"]
 }


### PR DESCRIPTION
## Summary
- Replace `.gitattributes` with the shared web project attributes template.
- Extend node TypeScript config for module TypeScript extensions.
- Align explicit JavaScript and TypeScript extension globs with the agreed order while preserving direct lint-staged commands.
- Order aggregate `lint` checks as format check, lint check, then typecheck.

## Verification
- `cmp` against the supplied `.gitattributes` content
- `git diff --check`
- pre-commit lint-staged