### PR TITLE
chore: add mts and cts autocorrect mappings

### DIFF
--- a/.autocorrectrc
+++ b/.autocorrectrc
@@ -3,3 +3,5 @@
 fileTypes:
   mjs: javascript
   cjs: javascript
+  mts: javascript
+  cts: javascript


### PR DESCRIPTION
## Summary

- Map `.mts` and `.cts` files to the `javascript` AutoCorrect parser.

## Rationale

This mirrors the existing `.mjs` and `.cjs` mappings so module-specific TypeScript files are handled consistently by AutoCorrect when they are present.

## Validation

- `yq --input-format yaml --output-format json '.' .autocorrectrc`
- Temp-file AutoCorrect check confirming `.mts` and `.cts` are linted through the updated config
- `pnpm run lint:autocorrect`
- `git diff --check`
- Husky pre-commit via `lint-staged` ran `oxfmt --no-error-on-unmatched-pattern`, `autocorrect --fix`, `cspell lint --no-progress --no-must-find-files --dot --gitignore`, `pnpm run i18n:types`, and `pnpm run lint:i18n`