### PR TITLE
chore(deps): block TypeScript major updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,9 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - version-update:semver-major
+      - dependency-name: 'typescript'
+        update-types:
+          - version-update:semver-major
     cooldown:
       default-days: 1
     open-pull-requests-limit: 999

--- a/.ncurc.mjs
+++ b/.ncurc.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'npm-check-updates';
 
-const majorLockedDependencies = new Set(['@types/node']);
+const majorLockedDependencies = new Set(['@types/node', 'typescript']);
 
 export default defineConfig({
   target: (dependencyName) => {


### PR DESCRIPTION
## Summary

- Ignore semantic-version major updates for `typescript` in Dependabot.
- Keep `npm-check-updates` on the installed TypeScript major while allowing minor and patch updates.

## Motivation

TypeScript 7 is available, but the current Vite checker, editor language-service plugin, and lint peer-dependency ecosystem are not ready for a clean single-version migration. Tracking the migration readiness separately avoids accidental automated upgrades while preserving TypeScript 6 maintenance updates.

See #2477 for the migration blockers and exit criteria.

## Impact

TypeScript 6 minor and patch updates remain eligible. Automated upgrades to TypeScript 7 and later major versions require an explicit policy change.

## Validation

- `yq eval '.' .github/dependabot.yaml`
- `pnpm run format:oxfmt:check`
- `pnpm run lint:oxlint`
- `pnpm exec ncu --filter typescript --jsonUpgraded` returned `{}`
- `git diff --check`
- Repository commit hooks completed successfully

Refs #2477