### PR TITLE
chore: refresh pnpm allow builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ allowBuilds:
   '@swc/core': true
   esbuild: true
   sharp: true
-  unrs-resolver: true
   workerd: true
 engineStrict: true
 minimumReleaseAge: 1440


### PR DESCRIPTION
Refresh pnpm build approvals against the current locked dependency graph. Remove stale package entries, preserve existing decisions for remaining locked dependencies, and approve newly pending builds. Generated by `scripts/update/pnpm-allow-builds.sh`.