### PR TITLE
chore: refresh pnpm allow builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ allowBuilds:
   '@swc/core': true
   esbuild: true
   sharp: true
-  unrs-resolver: true
   workerd: true
 engineStrict: true
 minimumReleaseAge: 1440


### PR DESCRIPTION
Reset pnpm build approvals for the current install environment and approve all discovered pending builds. Generated by `scripts/update/pnpm-allow-builds.sh`.