### PR TITLE
ci: cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,6 +8,10 @@ on:
       - '*'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- cancel stale CI runs for the same ref
- cancel stale Docker builds for the same ref
- keep tag builds isolated because the concurrency group includes the full ref

## Impact

New commits replace obsolete lint, test, build, and same-ref Docker runs. Distinct tag builds remain independent.

## Validation

- `yq eval '.'` for all workflow YAML files
- `pnpm run format:oxfmt:check`
- repository pre-commit checks