### PR TITLE
fix(i18n): generate types during extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format:oxfmt": "oxfmt",
     "format:oxfmt:check": "oxfmt --check",
     "i18n:check": "pnpm run i18n:status && pnpm run i18n:extract --ci --dry-run && pnpm run i18n:types --ci && pnpm run i18n:lint",
-    "i18n:extract": "i18next-cli extract",
+    "i18n:extract": "i18next-cli extract --with-types",
     "i18n:lint": "i18next-cli lint",
     "i18n:status": "i18next-cli status",
     "i18n:sync": "i18next-cli sync",


### PR DESCRIPTION
## Summary

- run the i18next type generator after extraction updates locale resources
- retain the independent `types --ci` check for detecting stale generated declarations

## Why

Running `pnpm run i18n:extract` previously updated locale resources without refreshing the generated TypeScript resource declarations. The declarations stayed stale until a separate type-generation or build command ran.

Adding the official `--with-types` option keeps generated types synchronized whenever extraction changes translation files, without changing extraction, translation, or runtime behavior.

## Validation

- `pnpm run i18n:extract`
- `pnpm run lint:i18n`
- `pnpm run format:oxfmt:check`
- `pnpm run typecheck`
- pre-commit hooks: Oxfmt, AutoCorrect, cspell, i18n types, and i18n lint