### PR TITLE
fix(docker): build assets on native platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim AS build
+FROM --platform=$BUILDPLATFORM node:24-slim AS build
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"


### PR DESCRIPTION
## Summary

- pin the Node build stage to BuildKit's native `BUILDPLATFORM`
- keep the final Nginx runtime images target-specific for `linux/amd64` and `linux/arm64`
- avoid running the architecture-independent Vite build under QEMU

## Root cause

The multi-platform Docker workflow ran the Node build stage once per target architecture. On the emulated ARM64 path, type-aware Oxlint failed to spawn `tsgolint` with `Cannot allocate memory (os error 12)`, causing the Docker publish workflow to fail before exporting the manifest.

Because the build stage only produces architecture-independent static assets, running it on the native build platform avoids QEMU without changing the runtime image platforms or weakening existing checks.

Failed run: https://github.com/donniean/react-app/actions/runs/30201161554

## Validation

- multi-platform Buildx build exported a local OCI index containing `linux/amd64` and `linux/arm64`
- ARM64 Nginx image browser smoke test passed with all 15 requests returning HTTP 200 and no console errors or warnings
- `pnpm run lint`
- `pnpm run test` (3 tests passed)
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化容器构建环境，提升跨平台构建的一致性与可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->