### PR TITLE
fix(tooling): ignore unmatched oxlint patterns

### DIFF
--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -9,7 +9,7 @@ export default {
     () => 'pnpm run lint:i18n',
   ],
   '*.{ts,tsx,mts,cts}': [() => 'tsc --build', 'vitest related --run'],
-  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix',
+  '*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}': 'oxlint --fix --no-error-on-unmatched-pattern',
   '*.css': 'stylelint --fix',
   '*.html': 'html-validate',
   '*.md': 'markdownlint --dot --fix',


### PR DESCRIPTION
## Summary

- allow the staged `oxlint` task to succeed when its input patterns contain no lintable files
- align the task with the existing unmatched-input handling used by other staged-file checks

## Why

`lint-staged` can select JavaScript or TypeScript paths that `oxlint` subsequently excludes. Without `--no-error-on-unmatched-pattern`, that valid no-op case exits with an error and blocks the commit even though there is nothing for `oxlint` to report.

## Validation

- `pnpm run lint`
- pre-commit `lint-staged` hook
- `pnpm exec oxlint --no-error-on-unmatched-pattern '__codex_missing_file__.ts'`