### PR TITLE
chore: refresh pnpm allow builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,6 @@
 allowBuilds:
-  '@parcel/watcher': true
   '@swc/core': true
   esbuild: true
-  sharp: true
   workerd: true
 engineStrict: true
 minimumReleaseAge: 1440


### PR DESCRIPTION
Reset pnpm build approvals for the current install environment and approve all discovered pending builds. Generated by `scripts/update/pnpm-allow-builds.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **维护**
  * 更新构建配置，调整部分工具的安装构建权限。
  * 保留现有核心构建工具配置，其他工作区设置不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->